### PR TITLE
Fix for paths with escaped characters

### DIFF
--- a/src/Dav.AspNetCore.Server/UriHelper.cs
+++ b/src/Dav.AspNetCore.Server/UriHelper.cs
@@ -12,7 +12,7 @@ internal static class UriHelper
         var uriString = string.Empty;
         for (var i = 0; i < uri.Segments.Length - 1; i++)
         {
-            uriString += uri.Segments[i];
+            uriString += Uri.UnescapeDataString(uri.Segments[i]);
         }
 
         return new Uri(uriString);
@@ -42,7 +42,7 @@ internal static class UriHelper
                 return uri;
         }
 
-        var relativePath = string.Join("", relativeTo.Segments.Skip(uri.Segments.Length));
+        var relativePath = string.Join("", relativeTo.Segments.Select(s => Uri.UnescapeDataString(s)).Skip(uri.Segments.Length));
         if (!relativePath.StartsWith("/"))
             relativePath = $"/{relativePath}";
 


### PR DESCRIPTION
In case of paths with escaped characters (like white spaces), there were some inconsistencies in URL decoding and encoding. I've tried to fix them (at least now it behaves correctly).